### PR TITLE
- Changed macro FLOATING_POINT_REPRESENTATION to BME280_FLOAT_ENABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The sensor driver package includes bme280.c, bme280.h and bme280_defs.h files.
 ## Version
 File | Version | Date
 -----|---------|-----
-bme280.c |  3.2.0     | 21 Mar 2017
-bme280.h |  3.2.0     | 21 Mar 2017
-bme280_defs.h |  3.2.0     | 21 Mar 2017
+bme280.c |  3.3.0     | 13 Jul 2017
+bme280.h |  3.3.0     | 13 Jul 2017
+bme280_defs.h |  3.3.0     | 13 Jul 2017
 
 ## Integration details
 * Integrate bme280.h, bme280_defs.h and bme280.c file in to the project.
@@ -40,8 +40,8 @@ struct bme280_dev dev;
 int8_t rslt = BME280_OK;
 
 /* Sensor_0 interface over SPI with native chip select line */
-dev.id = 0;
-dev.interface = BME280_SPI_INTF;
+dev.dev_id = 0;
+dev.intf = BME280_SPI_INTF;
 dev.read = user_spi_read;
 dev.write = user_spi_write;
 dev.delay_ms = user_delay_ms;
@@ -53,8 +53,8 @@ rslt = bme280_init(&dev);
 struct bme280_dev dev;
 int8_t rslt = BME280_OK;
 
-dev.id = BME280_I2C_ADDR_PRIM;
-dev.interface = BME280_I2C_INTF;
+dev.dev_id = BME280_I2C_ADDR_PRIM;
+dev.intf = BME280_I2C_INTF;
 dev.read = user_i2c_read;
 dev.write = user_i2c_write;
 dev.delay_ms = user_delay_ms;
@@ -65,74 +65,84 @@ Regarding compensation functions for temperature,pressure and humidity we have t
 1) Double precision floating point version
 2) Integer version
 
-By default, integer version is used in the API. If user needs double version, user has to
-enable FLOATING_POINT_REPRESENTATION macro in bme280_defs.h file.
+By default, integer version is used in the API. If the user needs the floating point version, the user has to uncomment BME280_FLOAT_ENABLE macro in bme280_defs.h file or add that to the compiler flags.
 
 In integer compensation functions, we also have below two implementations for pressure.
 1) For 32 bit machine.
 2) For 64 bit machine.
 
-By default, 64 bit variant is used in the API. If user wants 32 bit variant, user can disable the
-macro MACHINE_64_BIT in bme280_defs.h file.
+By default, 64 bit variant is used in the API. If the user wants 32 bit variant, the user can disable the
+macro BME280_64BIT_ENABLE in bme280_defs.h file.
 
-### Get sensor data
-#### Get sensor data in forced mode
+### Stream sensor data
+#### Stream sensor data in forced mode
 
 ``` c
-int8_t get_sensor_data_forced_mode(struct bme280_dev *dev)
+int8_t stream_sensor_data_forced_mode(struct bme280_dev *dev)
 {
-	int8_t rslt;
-	uint8_t settings_sel;
-	struct bme280_data comp_data;
+    int8_t rslt;
+    uint8_t settings_sel;
+    struct bme280_data comp_data;
 
-	/* Continuously get the sensor data */
-	while (1) {
-		dev->settings.osr_h = BME280_OVERSAMPLING_4X;
-		dev->settings.osr_p = BME280_OVERSAMPLING_4X;
-		dev->settings.osr_t = BME280_OVERSAMPLING_4X;
+    /* Recommended mode of operation: Indoor navigation */
+    dev->settings.osr_h = BME280_OVERSAMPLING_1X;
+    dev->settings.osr_p = BME280_OVERSAMPLING_16X;
+    dev->settings.osr_t = BME280_OVERSAMPLING_2X;
+    dev->settings.filter = BME280_FILTER_COEFF_16;
 
-		settings_sel = BME280_OSR_PRESS_SEL|BME280_OSR_TEMP_SEL|BME280_OSR_HUM_SEL;
+    settings_sel = BME280_OSR_PRESS_SEL | BME280_OSR_TEMP_SEL | BME280_OSR_HUM_SEL | BME280_FILTER_SEL;
 
-		rslt = bme280_set_sensor_settings(settings_sel, dev);
-		rslt = bme280_set_sensor_mode(BME280_FORCED_MODE, dev);
-		/* Give some delay for the sensor to go into force mode */
-		dev->delay_ms(5);
-		rslt = bme280_get_sensor_data(BME280_PRESS | BME280_HUM | BME280_TEMP, &comp_data, dev);
-		print_sensor_data(&comp_data);
-	}
-	return rslt;
+    rslt = bme280_set_sensor_settings(settings_sel, dev);
+
+    printf("Temperature, Pressure, Humidity\r\n");
+    /* Continuously stream sensor data */
+    while (1) {
+        rslt = bme280_set_sensor_mode(BME280_FORCED_MODE, dev);
+        /* Wait for the measurement to complete and print data @25Hz */
+        dev->delay_ms(40);
+        rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
+        print_sensor_data(&comp_data);
+    }
+    return rslt;
 }
 
 void print_sensor_data(struct bme280_data *comp_data)
 {
-#ifdef FLOATING_POINT_REPRESENTATION
-		printf("%0.2f\t\t%0.2f\t\t%0.2f\t\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+#ifdef BME280_FLOAT_ENABLE
+        printf("%0.2f, %0.2f, %0.2f\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #else
-		printf("%ld\t\t%ld\t\t%ld\t\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+        printf("%ld, %ld, %ld\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #endif
 }
-
 ```
-##### Get sensor data in normal mode
+##### Stream sensor data in normal mode
 ``` c
-int8_t get_sensor_data_normal_mode(struct bme280_dev *dev)
+int8_t stream_sensor_data_normal_mode(struct bme280_dev *dev)
 {
 	int8_t rslt;
 	uint8_t settings_sel;
 	struct bme280_data comp_data;
 
-	dev->settings.osr_h = BME280_OVERSAMPLING_4X;
-	dev->settings.osr_p = BME280_OVERSAMPLING_4X;
-	dev->settings.osr_t = BME280_OVERSAMPLING_4X;
+	/* Recommended mode of operation: Indoor navigation */
+	dev->settings.osr_h = BME280_OVERSAMPLING_1X;
+	dev->settings.osr_p = BME280_OVERSAMPLING_16X;
+	dev->settings.osr_t = BME280_OVERSAMPLING_2X;
+	dev->settings.filter = BME280_FILTER_COEFF_16;
+	dev->settings.standby_time = BME280_STANDBY_TIME_62_5_MS;
 
-	settings_sel = BME280_OSR_PRESS_SEL|BME280_OSR_TEMP_SEL|BME280_OSR_HUM_SEL;
+	settings_sel = BME280_OSR_PRESS_SEL;
+	settings_sel |= BME280_OSR_TEMP_SEL;
+	settings_sel |= BME280_OSR_HUM_SEL;
+	settings_sel |= BME280_STANDBY_SEL;
+	settings_sel |= BME280_FILTER_SEL;
 	rslt = bme280_set_sensor_settings(settings_sel, dev);
 	rslt = bme280_set_sensor_mode(BME280_NORMAL_MODE, dev);
-	/* Give some delay for the sensor to go into normal mode */
-	dev->delay_ms(5);
-	
+
+	printf("Temperature, Pressure, Humidity\r\n");
 	while (1) {
-		rslt = bme280_get_sensor_data(BME280_PRESS | BME280_HUM | BME280_TEMP, &comp_data, dev);
+		/* Delay while the sensor completes a measurement */
+		dev->delay_ms(70);
+		rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
 		print_sensor_data(&comp_data);
 	}
 
@@ -141,12 +151,129 @@ int8_t get_sensor_data_normal_mode(struct bme280_dev *dev)
 
 void print_sensor_data(struct bme280_data *comp_data)
 {
-#ifdef FLOATING_POINT_REPRESENTATION
-		printf("%0.2f\t\t%0.2f\t\t%0.2f\t\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+#ifdef BME280_FLOAT_ENABLE
+        printf("%0.2f, %0.2f, %0.2f\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #else
-		printf("%ld\t\t%ld\t\t%ld\t\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+        printf("%ld, %ld, %ld\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #endif
 }
+```
+
+### Templates for function pointers
+``` c
+
+void user_delay_ms(uint32_t period)
+{
+    /*
+     * Return control or wait,
+     * for a period amount of milliseconds
+     */
+}
+
+int8_t user_spi_read(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    int8_t rslt = 0; /* Return 0 for Success, non-zero for failure */
+
+    /*
+     * The parameter dev_id can be used as a variable to select which Chip Select pin has
+     * to be set low to activate the relevant device on the SPI bus
+     */
+
+    /*
+     * Data on the bus should be like
+     * |----------------+---------------------+-------------|
+     * | MOSI           | MISO                | Chip Select |
+     * |----------------+---------------------|-------------|
+     * | (don't care)   | (don't care)        | HIGH        |
+     * | (reg_addr)     | (don't care)        | LOW         |
+     * | (don't care)   | (reg_data[0])       | LOW         |
+     * | (....)         | (....)              | LOW         |
+     * | (don't care)   | (reg_data[len - 1]) | LOW         |
+     * | (don't care)   | (don't care)        | HIGH        |
+     * |----------------+---------------------|-------------|
+     */
+
+    return rslt;
+}
+
+int8_t user_spi_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    int8_t rslt = 0; /* Return 0 for Success, non-zero for failure */
+
+    /*
+     * The parameter dev_id can be used as a variable to select which Chip Select pin has
+     * to be set low to activate the relevant device on the SPI bus
+     */
+
+    /*
+     * Data on the bus should be like
+     * |---------------------+--------------+-------------|
+     * | MOSI                | MISO         | Chip Select |
+     * |---------------------+--------------|-------------|
+     * | (don't care)        | (don't care) | HIGH        |
+     * | (reg_addr)          | (don't care) | LOW         |
+     * | (reg_data[0])       | (don't care) | LOW         |
+     * | (....)              | (....)       | LOW         |
+     * | (reg_data[len - 1]) | (don't care) | LOW         |
+     * | (don't care)        | (don't care) | HIGH        |
+     * |---------------------+--------------|-------------|
+     */
+
+    return rslt;
+}
+
+int8_t user_i2c_read(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    int8_t rslt = 0; /* Return 0 for Success, non-zero for failure */
+
+    /*
+     * The parameter dev_id can be used as a variable to store the I2C address of the device
+     */
+
+    /*
+     * Data on the bus should be like
+     * |------------+---------------------|
+     * | I2C action | Data                |
+     * |------------+---------------------|
+     * | Start      | -                   |
+     * | Write      | (reg_addr)          |
+     * | Stop       | -                   |
+     * | Start      | -                   |
+     * | Read       | (reg_data[0])       |
+     * | Read       | (....)              |
+     * | Read       | (reg_data[len - 1]) |
+     * | Stop       | -                   |
+     * |------------+---------------------|
+     */
+
+    return rslt;
+}
+
+int8_t user_i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint16_t len)
+{
+    int8_t rslt = 0; /* Return 0 for Success, non-zero for failure */
+
+    /*
+     * The parameter dev_id can be used as a variable to store the I2C address of the device
+     */
+
+    /*
+     * Data on the bus should be like
+     * |------------+---------------------|
+     * | I2C action | Data                |
+     * |------------+---------------------|
+     * | Start      | -                   |
+     * | Write      | (reg_addr)          |
+     * | Write      | (reg_data[0])       |
+     * | Write      | (....)              |
+     * | Write      | (reg_data[len - 1]) |
+     * | Stop       | -                   |
+     * |------------+---------------------|
+     */
+
+    return rslt;
+}
+
 ```
 
 ## Copyright (C) 2016 - 2017 Bosch Sensortec GmbH

--- a/bme280.h
+++ b/bme280.h
@@ -40,8 +40,8 @@
  * patent rights of the copyright holder.
  *
  * @file	bme280.h
- * @date	21 Mar 2017
- * @version	3.2.0
+ * @date	13 Jul 2017
+ * @version	3.3.0
  * @brief
  *
  */

--- a/bme280_defs.h
+++ b/bme280_defs.h
@@ -40,8 +40,8 @@
  * patent rights of the copyright holder.
  *
  * @file	bme280_defs.h
- * @date	21 Mar 2017
- * @version	3.2.0
+ * @date	13 Jul 2017
+ * @version	3.3.0
  * @brief
  *
  */
@@ -120,8 +120,15 @@
 #endif
 #endif
 
-/* #define FLOATING_POINT_REPRESENTATION */
-#define MACHINE_64_BIT
+#ifndef BME280_FLOAT_ENABLE
+//#define BME280_FLOAT_ENABLE
+#endif
+
+#ifndef BME280_FLOAT_ENABLE
+#	ifndef BME280_64BIT_ENABLE
+#		define BME280_64BIT_ENABLE
+#	endif
+#endif
 
 #ifndef TRUE
 #define TRUE                UINT8_C(1)
@@ -131,43 +138,43 @@
 #endif
 
 /**\name I2C addresses */
-#define BME280_I2C_ADDR_PRIM		UINT8_C(0x76)
+#define BME280_I2C_ADDR_PRIM	UINT8_C(0x76)
 #define BME280_I2C_ADDR_SEC		UINT8_C(0x77)
 
 /**\name BME280 chip identifier */
 #define BME280_CHIP_ID  UINT8_C(0x60)
 
 /**\name Register Address */
-#define BME280_CHIP_ID_ADDR			UINT8_C(0xD0)
-#define BME280_RESET_ADDR			UINT8_C(0xE0)
+#define BME280_CHIP_ID_ADDR					UINT8_C(0xD0)
+#define BME280_RESET_ADDR					UINT8_C(0xE0)
 #define BME280_TEMP_PRESS_CALIB_DATA_ADDR	UINT8_C(0x88)
 #define BME280_HUMIDITY_CALIB_DATA_ADDR		UINT8_C(0xE1)
-#define BME280_PWR_CTRL_ADDR			UINT8_C(0xF4)
-#define BME280_CTRL_HUM_ADDR			UINT8_C(0xF2)
-#define BME280_CTRL_MEAS_ADDR			UINT8_C(0xF4)
-#define BME280_CONFIG_ADDR			UINT8_C(0xF5)
-#define BME280_DATA_ADDR			UINT8_C(0xF7)
+#define BME280_PWR_CTRL_ADDR				UINT8_C(0xF4)
+#define BME280_CTRL_HUM_ADDR				UINT8_C(0xF2)
+#define BME280_CTRL_MEAS_ADDR				UINT8_C(0xF4)
+#define BME280_CONFIG_ADDR					UINT8_C(0xF5)
+#define BME280_DATA_ADDR					UINT8_C(0xF7)
 
 /**\name API success code */
-#define BME280_OK				INT8_C(0)
+#define BME280_OK					INT8_C(0)
 /**\name API error codes */
 #define BME280_E_NULL_PTR			INT8_C(-1)
-#define BME280_E_DEV_NOT_FOUND			INT8_C(-2)
-#define BME280_E_INVALID_LEN			INT8_C(-3)
+#define BME280_E_DEV_NOT_FOUND		INT8_C(-2)
+#define BME280_E_INVALID_LEN		INT8_C(-3)
 #define BME280_E_COMM_FAIL			INT8_C(-4)
-#define BME280_E_SLEEP_MODE_FAIL		INT8_C(-5)
+#define BME280_E_SLEEP_MODE_FAIL	INT8_C(-5)
 /**\name API warning codes */
-#define BME280_W_INVALID_OSR_MACRO		UINT8_C(1)
+#define BME280_W_INVALID_OSR_MACRO	UINT8_C(1)
 
 /**\name Macros related to size */
 #define BME280_TEMP_PRESS_CALIB_DATA_LEN	UINT8_C(26)
 #define BME280_HUMIDITY_CALIB_DATA_LEN		UINT8_C(7)
-#define BME280_P_T_H_DATA_LEN			UINT8_C(8)
+#define BME280_P_T_H_DATA_LEN				UINT8_C(8)
 
 /**\name Sensor power modes */
-#define	BME280_SLEEP_MODE			UINT8_C(0x00)
-#define	BME280_FORCED_MODE			UINT8_C(0x01)
-#define	BME280_NORMAL_MODE			UINT8_C(0x03)
+#define	BME280_SLEEP_MODE		UINT8_C(0x00)
+#define	BME280_FORCED_MODE		UINT8_C(0x01)
+#define	BME280_NORMAL_MODE		UINT8_C(0x03)
 
 /**\name Macro to combine two 8 bit data's to form a 16 bit data */
 #define BME280_CONCAT_BYTES(msb, lsb)     (((uint16_t)msb << 8) | (uint16_t)lsb)
@@ -184,17 +191,17 @@
 #define BME280_GET_BITS_POS_0(reg_data, bitname)  (reg_data & (bitname##_MSK))
 
 /**\name Macros for bit masking */
-#define BME280_SENSOR_MODE_MSK		UINT8_C(0x03)
-#define BME280_SENSOR_MODE_POS		UINT8_C(0x00)
+#define BME280_SENSOR_MODE_MSK	UINT8_C(0x03)
+#define BME280_SENSOR_MODE_POS	UINT8_C(0x00)
 
 #define BME280_CTRL_HUM_MSK		UINT8_C(0x07)
 #define BME280_CTRL_HUM_POS		UINT8_C(0x00)
 
-#define BME280_CTRL_PRESS_MSK		UINT8_C(0x1C)
-#define BME280_CTRL_PRESS_POS		UINT8_C(0x02)
+#define BME280_CTRL_PRESS_MSK	UINT8_C(0x1C)
+#define BME280_CTRL_PRESS_POS	UINT8_C(0x02)
 
-#define BME280_CTRL_TEMP_MSK		UINT8_C(0xE0)
-#define BME280_CTRL_TEMP_POS		UINT8_C(0x05)
+#define BME280_CTRL_TEMP_MSK	UINT8_C(0xE0)
+#define BME280_CTRL_TEMP_POS	UINT8_C(0x05)
 
 #define BME280_FILTER_MSK		UINT8_C(0x1C)
 #define BME280_FILTER_POS		UINT8_C(0x02)
@@ -205,18 +212,18 @@
 /**\name Sensor component selection macros
    These values are internal for API implementation. Don't relate this to
    data sheet.*/
-#define BME280_PRESS			UINT8_C(1)
+#define BME280_PRESS		UINT8_C(1)
 #define BME280_TEMP			UINT8_C(1 << 1)
 #define BME280_HUM			UINT8_C(1 << 2)
 #define BME280_ALL			UINT8_C(0x07)
 
 /**\name Settings selection macros */
 #define BME280_OSR_PRESS_SEL		UINT8_C(1)
-#define BME280_OSR_TEMP_SEL		UINT8_C(1 << 1)
-#define BME280_OSR_HUM_SEL		UINT8_C(1 << 2)
-#define BME280_FILTER_SEL		UINT8_C(1 << 3)
-#define BME280_STANDBY_SEL		UINT8_C(1 << 4)
-#define BME280_ALL_SETTINGS_SEL	UINT8_C(0x1F)
+#define BME280_OSR_TEMP_SEL			UINT8_C(1 << 1)
+#define BME280_OSR_HUM_SEL			UINT8_C(1 << 2)
+#define BME280_FILTER_SEL			UINT8_C(1 << 3)
+#define BME280_STANDBY_SEL			UINT8_C(1 << 4)
+#define BME280_ALL_SETTINGS_SEL		UINT8_C(0x1F)
 
 /**\name Oversampling macros */
 #define BME280_NO_OVERSAMPLING		UINT8_C(0x00)
@@ -228,7 +235,7 @@
 
 /**\name Standby duration selection macros */
 #define BME280_STANDBY_TIME_1_MS              (0x00)
-#define BME280_STANDBY_TIME_62_5_MS             (0x01)
+#define BME280_STANDBY_TIME_62_5_MS           (0x01)
 #define BME280_STANDBY_TIME_125_MS			  (0x02)
 #define BME280_STANDBY_TIME_250_MS            (0x03)
 #define BME280_STANDBY_TIME_500_MS            (0x04)
@@ -295,7 +302,7 @@ struct bme280_calib_data {
  * @brief bme280 sensor structure which comprises of temperature, pressure and
  * humidity data
  */
-#ifdef FLOATING_POINT_REPRESENTATION
+#ifdef BME280_FLOAT_ENABLE
 struct bme280_data {
 	/*! Compensated pressure */
 	double pressure;
@@ -352,9 +359,9 @@ struct bme280_dev {
 	/*! Chip Id */
 	uint8_t chip_id;
 	/*! Device Id */
-	uint8_t id;
+	uint8_t dev_id;
 	/*! SPI/I2C interface */
-	enum bme280_intf interface;
+	enum bme280_intf intf;
 	/*! Read function pointer */
 	bme280_com_fptr_t read;
 	/*! Write function pointer */

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,22 @@
 # Change Log
 All notable changes to BME280 Sensor API will be documented in this file.
 
+## v3.3.0, 13 Jul 2017
+### Changed
+	- Changed macro FLOATING_POINT_REPRESENTATION to BME280_FLOAT_ENABLE
+	- Changed member id to dev_id in struct bme280_dev
+	- Changed member interface to intf in struct bme280_dev
+	- Changed variable length array in bme280_set_regs to fixed length array to allow a max of 10 registers to be written.
+	- Fixed bug with shifting in parse_sensor_data
+	- Changed macro MACHINE_64_BIT to BME280_64BIT_ENABLE
+	- Updated example in the README.md file and added function pointer templates
+	
 ## v3.2.0, 21 Mar 2017
 ### Changed
 	- API for putting sensor into sleep mode changed.
 	- Pressure, Temperature out of range data clipped.
 	- 64 bit pressure compensation changed.
+	
 ## v3.1.0, 8 Mar 2017
 ### Added
 	- Device settings APIs.
@@ -13,7 +24,7 @@ All notable changes to BME280 Sensor API will be documented in this file.
 	- Compensations functions, integer datatype 64bit for Pressure.
 ### Changed
 	- Internal functions related to power mode.
-		
+
 ## v3.0.0, 17 Feb 2017
 ### Added
 	Below functionalities are supported


### PR DESCRIPTION
- Changed member id to dev_id in struct bme280_dev
- Changed member interface to intf in struct bme280_dev
- Changed variable length array in bme280_set_regs to fixed length array to allow a max of 10 registers to be written.
- Fixed bug with shifting in parse_sensor_data
- Changed macro MACHINE_64_BIT to BME280_64BIT_ENABLE
- Updated example in the README.md file and added function pointer templates